### PR TITLE
Comply with the linter

### DIFF
--- a/tests/powerful/test_prime.py
+++ b/tests/powerful/test_prime.py
@@ -1,3 +1,5 @@
+import pytest
+
 from powerful.prime import Prime, is_prime
 
 
@@ -57,10 +59,5 @@ class TestPrime:
         p = 1332141235453512342314655513
 
         # act
-        try:
-            prime = Prime(p)
-        except:
-            prime = False
-
-        # assert
-        assert not prime
+        with pytest.raises(ValueError, match="not prime"):
+            Prime(p)


### PR DESCRIPTION
The E722 linter rule was violated due to a blind except in the test suite.

I have refactored the offending test in tests\powerful\test_prime.py:test_prime_creation_failure
It now uses a more conventional way in pytest to check that a line of code raises an error using `with pytest.raises`.